### PR TITLE
When loading a model, mao to the device being used

### DIFF
--- a/BTR.py
+++ b/BTR.py
@@ -300,7 +300,7 @@ class ImpalaCNNLargeIQN(nn.Module):
 
     def load_checkpoint(self, name):
         #print('... loading checkpoint ...')
-        self.load_state_dict(torch.load(name))
+        self.load_state_dict(torch.load(name, map_location=self.device))
 
 
 ################# Now Entering the Prioritized Experience Replay Section


### PR DESCRIPTION
If a model is trained via gpu for example but someone wants to load it with the device cpu, torch will throw an error. Adding a `map_location=self.device` to `torch.load` fixes the issue.