### PR TITLE
Use Path instead of plain strings for paths

### DIFF
--- a/DolphinEnv.py
+++ b/DolphinEnv.py
@@ -182,7 +182,7 @@ class DolphinEnv:
         (self.instance_info_folder/f'instance_id{i}.txt').write_text(str(i))
 
         exe_path = self.project_folder / f'dolphin{i}' / 'Dolphin.exe'
-        script_path = self.project_folder / DolphinScript.py
+        script_path = self.project_folder / 'DolphinScript.py'
 
         # launch the process
         cmd = (

--- a/DolphinEnv.py
+++ b/DolphinEnv.py
@@ -72,13 +72,13 @@ class DolphinEnv:
     def __init__(self, num_envs, gamename="LC", gamefile="mkw.iso", project_folder=None,
                  games_folder=None):
 
-        script_directory = os.path.dirname(os.path.abspath(__file__))
+        script_directory = Path(os.path.dirname(os.path.abspath(__file__)))
 
         if(project_folder == None):
             project_folder = script_directory
 
         if(games_folder == None):
-            games_folder = script_directory + r"\\game\\"
+            games_folder = script_directory / "game"
 
         self.num_envs = num_envs
         self.gamename = gamename
@@ -181,11 +181,14 @@ class DolphinEnv:
         (self.instance_info_folder/'pid_num.txt').write_text(str(i))
         (self.instance_info_folder/f'instance_id{i}.txt').write_text(str(i))
 
+        exe_path = self.project_folder / f'dolphin{i}' / 'Dolphin.exe'
+        script_path = self.project_folder / DolphinScript.py
+
         # launch the process
         cmd = (
-            f'cmd /c {self.project_folder}/dolphin{i}\\Dolphin.exe '
+            f'cmd /c {exe_path} '
             f'--no-python-subinterpreters '
-            f'--script "{self.project_folder}\\DolphinScript.py" '
+            f'--script "{script_path}" '
             f'\\b --exec="{self.games_folder/self.gamefile}"'
         )
         print(f"[Master] Opening File: {cmd}")

--- a/DolphinScript.py
+++ b/DolphinScript.py
@@ -10,7 +10,9 @@ import inspect
 from pathlib import Path
 
 script_directory = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
-shared_site_path = Path(script_directory) / "shared_site.txt"
+script_directory = Path(script_directory)
+
+shared_site_path = script_directory / "shared_site.txt"
 
 # add libraries from your python install (needs to match dolphin version (currently 3.12))
 if shared_site_path.exists() and shared_site_path.is_file():
@@ -443,7 +445,7 @@ class DolphinInstance:
 
         # reset environment back to savestate
         save_state_path = save_states_path / f"RMCP01.s0{x}"
-        savestate.load_from_file(save_state_path)
+        savestate.load_from_file(str(save_state_path))
 
         self.memory_tracker = Memory()
 

--- a/DolphinScript.py
+++ b/DolphinScript.py
@@ -41,7 +41,7 @@ def increment_alive(path='alive.txt'):
     path.write_text(str(alive_num + 1))
     return alive_num
 
-save_states_path = script_directory + f"\\MarioKartSaveStates\\"
+save_states_path = script_directory / "MarioKartSaveStates"
 
 instance_info_folder = Path('instance_info')
 
@@ -442,7 +442,8 @@ class DolphinInstance:
         x = random.randint(2, 8)
 
         # reset environment back to savestate
-        savestate.load_from_file(save_states_path + f"RMCP01.s0{x}")
+        save_state_path = save_states_path / f"RMCP01.s0{x}"
+        savestate.load_from_file(save_state_path)
 
         self.memory_tracker = Memory()
 


### PR DESCRIPTION
Use the `Path` class instead of plain strings for paths everywhere.
Intended for adding future support for other OSes like Linux