### PR TITLE
Untrack shared memory in python 3.13+

### DIFF
--- a/DolphinScript.py
+++ b/DolphinScript.py
@@ -314,7 +314,11 @@ class DolphinInstance:
 
         try:
             # setup shared memory
-            self.shm = shared_memory.SharedMemory(name="states_shm")
+            if(sys.version_info[1] < 13):
+                self.shm = shared_memory.SharedMemory(name="states_shm")
+            else:
+                # Make sure that the shared memory doesn't get deleted on upon exiting script by setting track=False
+                self.shm = shared_memory.SharedMemory(name="states_shm", track=False)
             self.states = np.ndarray(
                 (self.num_envs, self.framestack, self.window_y, self.window_x),
                 dtype=np.uint8,


### PR DESCRIPTION
Tracking shared memory is a new feature added in python 3. If enabled and used in DolphinScript, upon exit it deletes the shared memory which is bad if it was just a crash and we're going to restart as the shared memory is still needed. First we check for the python version and then disable tracking if it's 3.13+.  More info about the parameter on docs:

https://docs.python.org/3/library/multiprocessing.shared_memory.html