### PR TITLE
Fix scripts error after downloading files

### DIFF
--- a/scripts/download_dolphin.py
+++ b/scripts/download_dolphin.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 from common import download_file, extract_zip

--- a/scripts/download_savestates.py
+++ b/scripts/download_savestates.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 from common import download_file, extract_zip


### PR DESCRIPTION
In some scripts I simply forgot importing the module `os`, added the imports in this PR.