### PR TITLE
Change path handling for mac os support

### DIFF
--- a/DolphinEnv.py
+++ b/DolphinEnv.py
@@ -102,7 +102,7 @@ class DolphinEnv:
         self.project_folder = Path(project_folder) if not isinstance(project_folder, Path) else project_folder
         self.games_folder = Path(games_folder) if not isinstance(games_folder, Path) else games_folder
         self._check_iso_validity()
-        self.instance_info_folder = Path('instance_info')
+        self.instance_info_folder = self.project_folder / Path('instance_info')
         self.instance_info_folder.mkdir(exist_ok=True)
 
         # write the number of envs for the slaves to read
@@ -161,7 +161,7 @@ class DolphinEnv:
             print("The ROM provided is valid.")
 
     def increment_alive(self, path='alive.txt'):
-        path = Path(path)
+        path = self.project_folder / Path(path)
         alive_num = int(path.read_text().strip()) if path.exists() else 0
         path.write_text(str(alive_num + 1))
         return alive_num
@@ -215,7 +215,7 @@ class DolphinEnv:
         print(f"[Master] Dolphin {i} connected!")
 
         # now proceed with your alive.txt + PID‐file handshake
-        alive_path = Path('alive.txt')
+        alive_path = self.project_folder / Path('alive.txt')
         while int(alive_path.read_text()) < alive_num + 2:
             time.sleep(0.05)
 

--- a/DolphinScript.py
+++ b/DolphinScript.py
@@ -38,14 +38,14 @@ except Exception as e:
     raise Exception("stop")
 
 def increment_alive(path='alive.txt'):
-    path = Path(path)
+    path = script_directory / Path(path)
     alive_num = int(path.read_text().strip()) if path.exists() else 0
     path.write_text(str(alive_num + 1))
     return alive_num
 
 save_states_path = script_directory / "MarioKartSaveStates"
 
-instance_info_folder = Path('instance_info')
+instance_info_folder = script_directory / Path('instance_info')
 
 # Read pid from pid_num.txt
 pid = int((instance_info_folder / 'pid_num.txt').read_text().strip())
@@ -68,10 +68,10 @@ def log_exc(exc: BaseException):
         f.write('\n\n')
 
 
-FILE_PATH = Path.cwd() / "shared_value.txt"
+FILE_PATH = script_directory / "shared_value.txt"
 
 if not FILE_PATH.exists():
-    FILE_PATH = Path.cwd().parent / "shared_value.txt"
+    FILE_PATH = script_directory.parent / "shared_value.txt"
 
 print(f"FILE_PATH: {FILE_PATH}")
 


### PR DESCRIPTION
In Mac OS, when the DolphinScripy.py is ran, the current directory it shows is `/` (the root directory), unlike Linux and Mac OS where the currently directory would be inside a folder in the project directory.

The proposed solution isn't necessary clean, basically we would always make all the relevant files (`alive.txt` etc) in the project directory.
