### PR TITLE
Download dolphin for mac via scripts

### DIFF
--- a/scripts/common.py
+++ b/scripts/common.py
@@ -1,7 +1,10 @@
 import os
+import zipfile
+import tarfile
+
 import requests
 from tqdm import tqdm
-import zipfile
+
 
 def download_file(url, zip_file):
     print(f"Downloading {zip_file}...")
@@ -28,5 +31,14 @@ def extract_zip(zip_file_path, extract_to_dir):
     print(f"Extracting {zip_file_path} to {extract_to_dir}")
     with zipfile.ZipFile(zip_file_path, 'r') as zip_ref:
         zip_ref.extractall(extract_to_dir)
+
+    print("Extraction complete!")
+
+def extract_tar(tar_file_path, extract_to_dir):
+    os.makedirs(extract_to_dir, exist_ok=True)
+
+    print(f"Extracting {tar_file_path} to {extract_to_dir}")
+    with tarfile.open(file_path, 'r:gz') as tar_file:
+        tar_file.extractall(path=extract_to_dir)
 
     print("Extraction complete!")

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -38,7 +38,7 @@ def extract_tar(tar_file_path, extract_to_dir):
     os.makedirs(extract_to_dir, exist_ok=True)
 
     print(f"Extracting {tar_file_path} to {extract_to_dir}")
-    with tarfile.open(file_path, 'r:gz') as tar_file:
+    with tarfile.open(tar_file_path, 'r:gz') as tar_file:
         tar_file.extractall(path=extract_to_dir)
 
     print("Extraction complete!")

--- a/scripts/download_dolphin.py
+++ b/scripts/download_dolphin.py
@@ -1,15 +1,26 @@
 import os
 from pathlib import Path
+import platform
 
 from common import download_file, extract_zip
 
-SAVESTATE_URL = "https://github.com/VIPTankz/Wii-RL/releases/download/dolphin/dolphin0.zip"
+DOLPHIN_WIN_URL = "https://github.com/VIPTankz/Wii-RL/releases/download/dolphin/dolphin0.zip"
+DOLPHIN_MAC_ARM_URL = "https://github.com/unexploredtest/dolphin/releases/download/dolphin-wii-rl/DolphinMacArm.zip"
+DOLPHIN_MAC_X86_URL = "https://github.com/unexploredtest/dolphin/releases/download/dolphin-wii-rl/DolphinMacx86.zip"
 ZIP_NAME = "Dolphin.zip"
 
 def main():
     current_directory = Path.cwd()
 
-    download_file(SAVESTATE_URL, ZIP_NAME)
+    if(platform.system() == "Windows"):
+        download_file(DOLPHIN_WIN_URL, ZIP_NAME)
+    elif(platform.system() == "Darwin" and platform.machine() == "arm64"):
+        download_file(DOLPHIN_MAC_ARM_URL, ZIP_NAME)
+    elif(platform.system() == "Darwin" and platform.machine() == "x86_64"):
+        download_file(DOLPHIN_MAC_X86_URL, ZIP_NAME)
+    else:
+        raise RuntimeError(f"The operating system '{platform.system()}' is not supported.")
+    
     extract_zip(ZIP_NAME, current_directory)
 
     os.remove(ZIP_NAME)

--- a/scripts/download_dolphin.py
+++ b/scripts/download_dolphin.py
@@ -2,26 +2,28 @@ import os
 from pathlib import Path
 import platform
 
-from common import download_file, extract_zip
+from common import download_file, extract_zip, extract_tar
 
 DOLPHIN_WIN_URL = "https://github.com/VIPTankz/Wii-RL/releases/download/dolphin/dolphin0.zip"
 DOLPHIN_MAC_ARM_URL = "https://github.com/unexploredtest/dolphin/releases/download/dolphin-wii-rl/DolphinMacArm.zip"
 DOLPHIN_MAC_X86_URL = "https://github.com/unexploredtest/dolphin/releases/download/dolphin-wii-rl/DolphinMacx86.zip"
 ZIP_NAME = "Dolphin.zip"
+TAR_NAME = "Dolphin.tar.gz"
 
 def main():
     current_directory = Path.cwd()
 
     if(platform.system() == "Windows"):
         download_file(DOLPHIN_WIN_URL, ZIP_NAME)
+        extract_zip(ZIP_NAME, current_directory)
     elif(platform.system() == "Darwin" and platform.machine() == "arm64"):
-        download_file(DOLPHIN_MAC_ARM_URL, ZIP_NAME)
+        download_file(DOLPHIN_MAC_ARM_URL, TAR_NAME)
+        extract_tar(TAR_NAME, current_directory)
     elif(platform.system() == "Darwin" and platform.machine() == "x86_64"):
-        download_file(DOLPHIN_MAC_X86_URL, ZIP_NAME)
+        download_file(DOLPHIN_MAC_X86_URL, TAR_NAME)
+        extract_tar(TAR_NAME, current_directory)
     else:
         raise RuntimeError(f"The operating system '{platform.system()}' is not supported.")
-    
-    extract_zip(ZIP_NAME, current_directory)
 
     os.remove(ZIP_NAME)
 

--- a/scripts/download_dolphin.py
+++ b/scripts/download_dolphin.py
@@ -5,8 +5,8 @@ import platform
 from common import download_file, extract_zip, extract_tar
 
 DOLPHIN_WIN_URL = "https://github.com/VIPTankz/Wii-RL/releases/download/dolphin/dolphin0.zip"
-DOLPHIN_MAC_ARM_URL = "https://github.com/unexploredtest/dolphin/releases/download/dolphin-wii-rl/DolphinMacArm.zip"
-DOLPHIN_MAC_X86_URL = "https://github.com/unexploredtest/dolphin/releases/download/dolphin-wii-rl/DolphinMacx86.zip"
+DOLPHIN_MAC_ARM_URL = "https://github.com/unexploredtest/dolphin/releases/download/dolphin-wii-rl/DolphinMacArm.tar.gz"
+DOLPHIN_MAC_X86_URL = "https://github.com/unexploredtest/dolphin/releases/download/dolphin-wii-rl/DolphinMacx86.tar.gz"
 ZIP_NAME = "Dolphin.zip"
 TAR_NAME = "Dolphin.tar.gz"
 
@@ -16,16 +16,17 @@ def main():
     if(platform.system() == "Windows"):
         download_file(DOLPHIN_WIN_URL, ZIP_NAME)
         extract_zip(ZIP_NAME, current_directory)
+        os.remove(ZIP_NAME)
     elif(platform.system() == "Darwin" and platform.machine() == "arm64"):
         download_file(DOLPHIN_MAC_ARM_URL, TAR_NAME)
         extract_tar(TAR_NAME, current_directory)
+        os.remove(TAR_NAME)
     elif(platform.system() == "Darwin" and platform.machine() == "x86_64"):
         download_file(DOLPHIN_MAC_X86_URL, TAR_NAME)
         extract_tar(TAR_NAME, current_directory)
+        os.remove(TAR_NAME)
     else:
         raise RuntimeError(f"The operating system '{platform.system()}' is not supported.")
-
-    os.remove(ZIP_NAME)
 
     print("Done!")
 


### PR DESCRIPTION
The script `download_dolphin.py` now supports downloading Dolphin, from the release builds below:

https://github.com/unexploredtest/dolphin/releases/tag/dolphin-wii-rl

The script supports both arm64 and x86_64 mac, though I haven't tested with x86_64 mac yet.

The executables downloaded from there require the users to have python installed through homebrew, more precisely python version `3.13.5`. It can't be any other minor version, it has to be `3.13`. I don't know if the exact micro version (`5`) is required.

Also changes to the configs have been made. Dual core mode is disabled as it causes crashes. The gpu api used is OpenGL as Metal straight up doesn't work and we get issues if we create more than 2 environments with Vulkan.