### PR TITLE
DolphinScript: Fix name check for savestate files

### DIFF
--- a/DolphinScript.py
+++ b/DolphinScript.py
@@ -445,7 +445,7 @@ class DolphinInstance:
         self.checkpoints.append(9999.)
 
         # pick a random state to reset to
-        save_states = [file for file in Path(save_states_path).rglob('*') if file.is_file() and ".s" in str(file)]
+        save_states = [file for file in Path(save_states_path).rglob('*') if file.is_file() and ".s" in file.name]
         savestate.load_from_file(str(random.choice(save_states)))
 
         self.memory_tracker = Memory()


### PR DESCRIPTION
When looking for savestate files, we check if they have ".s" in their name (which is what they should have). By mistake, we were checking if the full directory contained ".s" instead of checking the individual files. It's a small issue, but it doesn't hurt to fix, I suppose.